### PR TITLE
internal/match: add implicit cut operator, handle (c) vs c) in bullet lists

### DIFF
--- a/internal/match/dict.go
+++ b/internal/match/dict.go
@@ -178,7 +178,7 @@ func (d *Dict) split(text string, insert bool) []Word {
 			}
 
 			// More of our own.
-			for _, m := range allowedMismatches {
+			for _, m := range canonicalRewrites {
 				if string(w) == m.y {
 					w = append(w[:0], m.x...)
 				}
@@ -248,6 +248,10 @@ func foldRune(r rune) rune {
 
 	if 'A' <= r && r <= 'Z' {
 		r += 'a' - 'A'
+	}
+	if r == '(' || r == ')' {
+		// delete ( ) in (c) or notice(s)
+		return -1
 	}
 
 	return r
@@ -424,4 +428,20 @@ func markdownLinkSize(t string) int {
 		}
 	}
 	return 0
+}
+
+// canonicalRewrites is a list of pairs that are canonicalized during word splittting.
+// The words on the right are parsed as if they were the words on the left.
+// This happens during dictionary splitting, so canMisspell will never see any
+// of the words on the right.
+var canonicalRewrites = []struct {
+	x, y string
+}{
+	{"is", "are"},
+	{"it", "them"},
+	{"it", "they"},
+	{"the", "these"},
+	{"the", "this"},
+	{"the", "those"},
+	{"copy", "copies"}, // most plurals are handled as 1-letter typos
 }

--- a/internal/match/dict_test.go
+++ b/internal/match/dict_test.go
@@ -147,6 +147,10 @@ var insertSplitTests = []struct {
 	{"(C) 2020 Gopher®", "copyright 2020 gopher"},
 	{"© 2020 Gopher®", "copyright 2020 gopher"},
 	{"&copy; 2020 Gopher®", "copyright 2020 gopher"},
+	{"a b c (c) d", "a b c copyright d"},
+	{"a b c copyright d", "a b c copyright d"},
+	{"a b c © d", "a b c copyright d"},
+
 	{"http://golang.org", "http golang org"},
 	{"https://golang.org", "http golang org"},
 	{"the notice(s) must", "the notices must"},

--- a/internal/match/rematch_test.go
+++ b/internal/match/rematch_test.go
@@ -213,6 +213,15 @@ var matchTests = []struct {
 	{`abcdef`, `xbcdef`, 0, 1},
 	{`abcdef`, `abcdex`, 0, 1},
 
+	// canMisspell - c vs (c) (≡ copyright)
+	{`a b c d`, `a b c d`, 0, 4},
+	{`a b (c) d`, `a b c d`, 0, 4},
+	{`a b copyright d`, `a b c d`, 0, 4},
+	{`a b © d`, `a b c d`, 0, 4},
+	{`a b c d`, `a b (c) d`, 0, 4},
+	{`a b c d`, `a b copyright d`, 0, 4},
+	{`a b c d`, `a b © d`, 0, 4},
+
 	// canMisspellJoin
 	{`x noninfringement y`, `x non-infringement y`, 0, 4},
 

--- a/internal/match/rematch_test.go
+++ b/internal/match/rematch_test.go
@@ -65,6 +65,274 @@ a b c / d e f
 7	word e
 8	word f
 9	match 0
+
+a __3__ b c d
+0	word a
+1	alt 7
+2	any
+3	alt 7
+4	any
+5	alt 7
+6	any
+7	word b
+8	word c
+9	word d
+10	match 0
+
+a __4__ b c d
+0	word a
+1	alt 9
+2	any
+3	alt 9
+4	any
+5	alt 9
+6	any
+7	alt 9
+8	any
+9	word b
+10	word c
+11	word d
+12	cut [1, 9]
+13	match 0
+
+a __4__ b c d e
+0	word a
+1	alt 9
+2	any
+3	alt 9
+4	any
+5	alt 9
+6	any
+7	alt 9
+8	any
+9	word b
+10	word c
+11	word d
+12	cut [1, 9]
+13	word e
+14	match 0
+
+a __5__ b c d e f g
+0	word a
+1	alt 11
+2	any
+3	alt 11
+4	any
+5	alt 11
+6	any
+7	alt 11
+8	any
+9	alt 11
+10	any
+11	word b
+12	word c
+13	word d
+14	cut [1, 11]
+15	word e
+16	word f
+17	word g
+18	match 0
+
+a __5__ ((b c))?? d e f g
+0	word a
+1	alt 11
+2	any
+3	alt 11
+4	any
+5	alt 11
+6	any
+7	alt 11
+8	any
+9	alt 11
+10	any
+11	alt 14
+12	word b
+13	word c
+14	word d
+15	word e
+16	word f
+17	cut [1, 11]
+18	word g
+19	match 0
+
+a __5__ ((b c d))?? e f g h
+0	word a
+1	alt 11
+2	any
+3	alt 11
+4	any
+5	alt 11
+6	any
+7	alt 11
+8	any
+9	alt 11
+10	any
+11	alt 16
+12	word b
+13	word c
+14	word d
+15	cut [1, 11]
+16	word e
+17	word f
+18	word g
+19	cut [1, 11]
+20	word h
+21	match 0
+
+a __5__ ((b || c x)) d e f g
+0	word a
+1	alt 11
+2	any
+3	alt 11
+4	any
+5	alt 11
+6	any
+7	alt 11
+8	any
+9	alt 11
+10	any
+11	alt 14
+12	word b
+13	jump 16
+14	word c
+15	word x
+16	word d
+17	word e
+18	cut [1, 11]
+19	word f
+20	word g
+21	match 0
+
+a b ((__5__ c d))??
+0	word a
+1	word b
+2	alt 16
+3	alt 13
+4	any
+5	alt 13
+6	any
+7	alt 13
+8	any
+9	alt 13
+10	any
+11	alt 13
+12	any
+13	word c
+14	word d
+15	cut [3, 13]
+16	match 0
+
+a b ((__5__ c d))??
+0	word a
+1	word b
+2	alt 16
+3	alt 13
+4	any
+5	alt 13
+6	any
+7	alt 13
+8	any
+9	alt 13
+10	any
+11	alt 13
+12	any
+13	word c
+14	word d
+15	cut [3, 13]
+16	match 0
+
+a b __5__ c d ((x?? y?? z z z || y w w w))
+0	word a
+1	word b
+2	alt 12
+3	any
+4	alt 12
+5	any
+6	alt 12
+7	any
+8	alt 12
+9	any
+10	alt 12
+11	any
+12	word c
+13	word d
+14	alt 26
+15	alt 18
+16	word x
+17	cut [2, 12]
+18	alt 21
+19	word y
+20	cut [2, 12]
+21	word z
+22	cut [2, 12]
+23	word z
+24	word z
+25	jump 31
+26	word y
+27	cut [2, 12]
+28	word w
+29	word w
+30	word w
+31	match 0
+
+a b __5__ c __5__ d
+0	word a
+1	word b
+2	alt 12
+3	any
+4	alt 12
+5	any
+6	alt 12
+7	any
+8	alt 12
+9	any
+10	alt 12
+11	any
+12	word c
+13	cut [2, 12]
+14	alt 24
+15	any
+16	alt 24
+17	any
+18	alt 24
+19	any
+20	alt 24
+21	any
+22	alt 24
+23	any
+24	word d
+25	cut [14, 24]
+26	match 0
+
+The name __10__ may not be used.
+0	word the
+1	word name
+2	alt 22
+3	any
+4	alt 22
+5	any
+6	alt 22
+7	any
+8	alt 22
+9	any
+10	alt 22
+11	any
+12	alt 22
+13	any
+14	alt 22
+15	any
+16	alt 22
+17	any
+18	alt 22
+19	any
+20	alt 22
+21	any
+22	word may
+23	word not
+24	word be
+25	cut [2, 22]
+26	word used
+27	match 0
 `
 
 func TestCompile(t *testing.T) {
@@ -87,14 +355,19 @@ func TestCompile(t *testing.T) {
 
 func testProg(t *testing.T, dict *Dict, expr string) reProg {
 	if strings.Contains(expr, "/") {
-		var list []*reSyntax
+		var list []reProg
 		for _, str := range strings.Split(expr, "/") {
 			re, err := reParse(dict, str, false)
 			if err != nil {
 				t.Errorf("Parse(%q): %v", expr, err)
 				return nil
 			}
-			list = append(list, re)
+			prog, err := re.compile(nil, 0)
+			if err != nil {
+				t.Errorf("compile(%q): %v", expr, err)
+				return nil
+			}
+			list = append(list, prog)
 		}
 		return reCompileMulti(list)
 	}
@@ -104,7 +377,12 @@ func testProg(t *testing.T, dict *Dict, expr string) reProg {
 		t.Errorf("reParse(%q): %v", expr, err)
 		return nil
 	}
-	return re.compile(nil, 0)
+	prog, err := re.compile(nil, 0)
+	if err != nil {
+		t.Errorf("compile(%q): %v", expr, err)
+		return nil
+	}
+	return prog
 }
 
 var compileDFATests = `
@@ -141,7 +419,6 @@ a b c / a ((c | d)) e
 31 *:15 d:26 e:38
 38 d:18 f:24
 
-
 a b c / a ((c || d)) e
 0 a:3
 3 b:10 c:15 d:15
@@ -149,6 +426,143 @@ a b c / a ((c || d)) e
 13 m0
 15 e:18
 18 m1
+
+a __1__ b c d e
+0 a:3
+3 *:8 b:22
+8 b:11
+11 c:14
+14 d:17
+17 e:20
+20 m0
+22 b:11 c:14
+
+a __2__ b c d e
+0 a:3
+3 *:8 b:32
+8 *:13 b:27
+13 b:16
+16 c:19
+19 d:22
+22 e:25
+25 m0
+27 b:16 c:19
+32 *:13 b:27 c:39
+39 b:16 d:22
+
+a __3__ b c d e
+0 a:3
+3 *:8 b:49
+8 *:13 b:37
+13 *:18 b:32
+18 b:21
+21 c:24
+24 d:27
+27 e:30
+30 m0
+32 b:21 c:24
+37 *:18 b:32 c:44
+44 b:21 d:27
+49 *:13 b:37 c:56
+56 *:18 b:32 d:63
+63 b:21 e:30
+
+a __4__ b c d e
+0 a:3
+3 *:8 b:68
+8 *:13 b:54
+13 *:18 b:42
+18 *:23 b:37
+23 b:26
+26 c:29
+29 d:32
+32 e:35
+35 m0
+37 b:26 c:29
+42 *:23 b:37 c:49
+49 b:26 d:32
+54 *:18 b:42 c:61
+61 *:23 b:37 d:32
+68 *:13 b:54 c:75
+75 *:18 b:42 d:32
+
+a __5__ b c d e f g
+0 a:3
+3 *:8 b:93
+8 *:13 b:79
+13 *:18 b:65
+18 *:23 b:53
+23 *:28 b:48
+28 b:31
+31 c:34
+34 d:37
+37 e:40
+40 f:43
+43 g:46
+46 m0
+48 b:31 c:34
+53 *:28 b:48 c:60
+60 b:31 d:37
+65 *:23 b:53 c:72
+72 *:28 b:48 d:37
+79 *:18 b:65 c:86
+86 *:23 b:53 d:37
+93 *:13 b:79 c:100
+100 *:18 b:65 d:37
+
+a __5__ b __5__ c
+0 a:3
+3 *:8 b:31
+8 *:13 b:31
+13 *:18 b:31
+18 *:23 b:31
+23 *:28 b:31
+28 b:31
+31 *:36 c:59
+36 *:41 c:59
+41 *:46 c:59
+46 *:51 c:59
+51 *:56 c:59
+56 c:59
+59 m0
+
+The name __10__ may not be used
+0 the:3
+3 name:6
+6 *:11 may:185
+11 *:16 may:171
+16 *:21 may:157
+21 *:26 may:143
+26 *:31 may:129
+31 *:36 may:115
+36 *:41 may:101
+41 *:46 may:87
+46 *:51 may:75
+51 *:56 may:70
+56 may:59
+59 not:62
+62 be:65
+65 used:68
+68 m0
+70 may:59 not:62
+75 *:56 may:70 not:82
+82 may:59 be:65
+87 *:51 may:75 not:94
+94 *:56 may:70 be:65
+101 *:46 may:87 not:108
+108 *:51 may:75 be:65
+115 *:41 may:101 not:122
+122 *:46 may:87 be:65
+129 *:36 may:115 not:136
+136 *:41 may:101 be:65
+143 *:31 may:129 not:150
+150 *:36 may:115 be:65
+157 *:26 may:143 not:164
+164 *:31 may:129 be:65
+171 *:21 may:157 not:178
+178 *:26 may:143 be:65
+185 *:16 may:171 not:192
+192 *:21 may:157 be:65
 `
 
 func TestCompileDFA(t *testing.T) {
@@ -227,6 +641,11 @@ var matchTests = []struct {
 
 	// misspell split
 	{`i non-infringement j`, `i noninfringement j`, 0, 3},
+
+	{`a b ((__5__ c d))??`, `a b X X X c d`, 0, 7},
+	{`a b ((__5__ c d e))??`, `a b X X X c d e`, 0, 8},
+
+	{`a b __5__ c d ((x?? y?? z z z || y w w w))`, `a b X X X c d y z z z`, 0, 11},
 }
 
 func TestReDFAMatch(t *testing.T) {


### PR DESCRIPTION
This PR is a pair of commits.

The first handles allows (c) and c) to be treated as equivalent during text matches;
they're not already equivalent because (c) means "copyright".

The second adds an implicit cut operator after wildcard slots,
to greatly reduce the DFA construction cost and footprint.

See the individual commit messages for longer descriptions.
