### PR TITLE
licensecheck: add Trace function

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -249,3 +249,10 @@ func (s *Scanner) licenseURL(url string) (License, bool) {
 
 	return License{}, false
 }
+
+// Trace controls whether DFA execution prints debug tracing when stuck.
+// If n > 0 and the DFA has followed a path of at least n symbols since the last
+// matching state but hits a dead end, it prints out information about the dead end.
+func Trace(n int) {
+	match.TraceDFA = n
+}


### PR DESCRIPTION
Add the Trace function, which sets the match.TraceDFA variable.

This is invaluable for debugging uses of this package.

As one example, you are faced with what seems to be a fine Apache-2.0
license that nonetheless isn't matched by any LRE. You try to compare
the text to the LRE, but quickly realize that this task is toilsome
and inaccurate. Calling Trace and running again immediately reveals
that someone has s/product/bundle/, resulting in "reproduction" being
altered to "rebundleion". (True story.)

Trace is also useful when writing custom LREs to capture new license
variants.