### PR TITLE
internal/match: fix panic at EOF when TraceDFA > 0

### DIFF
--- a/internal/match/rematch.go
+++ b/internal/match/rematch.go
@@ -936,7 +936,7 @@ Words:
 		if start < 0 {
 			start = 0
 		}
-		println("DFA ran out of input at «", text[words[i-10].Lo:], "|", "EOF", "»\n")
+		println("DFA ran out of input at «", text[words[start].Lo:], "|", "EOF", "»\n")
 	}
 	return match, end
 }


### PR DESCRIPTION
With TraceDFA > 0, Scan sometimes panics by indexing a slice with a
negative value. This fixes the panic.

The fix is trivial: index the slice with a variable that was already
adjusted non-negative for the purpose but not used.