### PR TITLE
licenses: modifications to Apache-2.0

### DIFF
--- a/licenses/Apache-2.0.lre
+++ b/licenses/Apache-2.0.lre
@@ -46,12 +46,15 @@ exceptions:
 		((http))??
 		((www))??
 		.apache.org/licenses/LICENSE-2.0
+		((html))??
 	||
 		((http))??
 		aws.amazon.com/apache2.0/
 	))??
 
-	((or in the license file accompanying this file.))??
+	((or in the license file accompanying this
+		((file. || software.))
+	))??
 
 	((
 		((As well as the file __10__))??

--- a/licenses/Apache-2.0.lre
+++ b/licenses/Apache-2.0.lre
@@ -3,6 +3,11 @@ Apache License 2.0
 https://spdx.org/licenses/Apache-2.0.json
 http://www.apache.org/licenses/LICENSE-2.0
 https://opensource.org/licenses/Apache-2.0
+
+exceptions:
+  (( i || properties ))		https://github.com/apache/rocketmq-client-go/issues/590
+  (( except || expect ))	https://github.com/Dwarfartisan/goparsec2/issues/6
+  __1__ License, etc.		github.com/ltto/gomybatis@v5.1.7+incompatible and several others
 **//
 
 ((
@@ -93,21 +98,24 @@ https://opensource.org/licenses/Apache-2.0
    Definitions.
 
       "License" shall mean the terms and conditions for use, reproduction, and
-      distribution as defined by Sections 1 through 9 of this document.
+      distribution as defined by Sections 1 through 9 of __1__ document.
 
-      "Licensor" shall mean the copyright owner or entity authorized by the
+      (("Licensor" || "Restream"))
+      shall mean the copyright owner or entity authorized by the
       copyright owner that is granting the License.
 
       "Legal Entity" shall mean the union of the acting entity and all other
       entities that control, are controlled by, or are under common control with
-      that entity. For the purposes of this definition, "control" means (i) the
+      that entity. For the purposes of __1__ definition, "control" means (
+      (( i || properties || k ))
+      ) the
       power, direct or indirect, to cause the direction or management of such
       entity, whether by contract or otherwise, or (ii) ownership of fifty
       percent (50%) or more of the outstanding shares, or (iii) beneficial
       ownership of such entity.
 
       "You" (or "Your") shall mean an individual or Legal Entity exercising
-      permissions granted by this License.
+      permissions granted by __1__ License.
 
       "Source" form shall mean the preferred form for making modifications,
       including but not limited to software source code, documentation source,
@@ -116,7 +124,8 @@ https://opensource.org/licenses/Apache-2.0
       "Object" form shall mean any form resulting from mechanical transformation
       or translation of a Source form, including but not limited to compiled
       object code, generated documentation, and conversions to other media
-      types.
+      (( types || pointer ))
+      //** voyagermesh.dev_voyager **//
 
       "Work" shall mean the work of authorship, whether in Source or Object
       form, made available under the License, as indicated by a copyright notice
@@ -126,7 +135,7 @@ https://opensource.org/licenses/Apache-2.0
       "Derivative Works" shall mean any work, whether in Source or Object form,
       that is based on (or derived from) the Work and for which the editorial
       revisions, annotations, elaborations, or other modifications represent, as
-      a whole, an original work of authorship. For the purposes of this License,
+      a whole, an original work of authorship. For the purposes of __1__ License,
       Derivative Works shall not include works that remain separable from, or
       merely link (or bind by name) to the interfaces of, the Work and
       Derivative Works thereof.
@@ -136,13 +145,19 @@ https://opensource.org/licenses/Apache-2.0
       Derivative Works thereof, that is intentionally submitted to Licensor for
       inclusion in the Work by the copyright owner or by an individual or Legal
       Entity authorized to submit on behalf of the copyright owner. For the
-      purposes of this definition, "submitted" means any form of electronic,
-      verbal, or written communication sent to the Licensor or its
-      representatives, including but not limited to communication on
+      purposes of __1__ definition, "submitted" means any form of electronic,
+      verbal, or written
+      ((communication || token))
+      sent to the Licensor or its
+      representatives, including but not limited to
+      ((communication || token))
+      on
       ((electronic))??
       mailing lists, source code control systems, and issue tracking systems
       that are managed by, or on behalf of, the Licensor for the purpose of
-      discussing and improving the Work, but excluding communication that is
+      discussing and improving the Work, but excluding
+      ((communication || token))
+      that is
       conspicuously marked or otherwise designated in writing by the copyright
       owner as "Not a Contribution."
 
@@ -151,7 +166,7 @@ https://opensource.org/licenses/Apache-2.0
       subsequently incorporated within the Work.
 
    (( 2. ))??
-   Grant of Copyright License. Subject to the terms and conditions of this
+   Grant of Copyright License. Subject to the terms and conditions of __1__
    License, each Contributor hereby grants to You a perpetual, worldwide,
    non-exclusive, no-charge, royalty-free, irrevocable copyright license to
    reproduce, prepare Derivative Works of, publicly display, publicly perform,
@@ -159,18 +174,21 @@ https://opensource.org/licenses/Apache-2.0
    Object form.
 
    (( 3. ))??
-   Grant of Patent License. Subject to the terms and conditions of this License,
+   Grant of Patent License. Subject to the terms and conditions of __1__ License,
    each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
-   no-charge, royalty-free, irrevocable (except as stated in this section)
+   no-charge, royalty-free, irrevocable (
+   (( except || expect ))
+   as stated in __1__ section)
    patent license to make, have made, use, offer to sell, sell, import, and
    otherwise transfer the Work, where such license applies only to those patent
    claims licensable by such Contributor that are necessarily infringed by their
    Contribution(s) alone or by combination of their Contribution(s) with the
    Work to which such Contribution(s) was submitted. If You institute patent
    litigation against any entity (including a cross-claim or counterclaim in a
-   lawsuit) alleging that the Work or a Contribution incorporated within the
+   ((lawsuit || luit))
+   ) alleging that the Work or a Contribution incorporated within the
    Work constitutes direct or contributory patent infringement, then any patent
-   licenses granted to You under this License for that Work shall terminate as
+   licenses granted to You under __1__ License for that Work shall terminate as
    of the date such litigation is filed.
 
    (( 4. ))??
@@ -180,7 +198,7 @@ https://opensource.org/licenses/Apache-2.0
 
       (( 1. || (a) ))??
       You must give any other recipients of the Work or Derivative Works a copy
-      of this License; and
+      of __1__ License; and
 
       (( 2. || (b) ))??
       You must cause any modified files to carry prominent notices stating that
@@ -192,7 +210,7 @@ https://opensource.org/licenses/Apache-2.0
       the Source form of the Work, excluding those notices that do not pertain
       to any part of the Derivative Works; and
 
-      (( 4. || (d) ))??
+      (( 4. || (d) || (c) ))??
       If the Work includes a "NOTICE" text file as part of its distribution,
       then any Derivative Works that You distribute must include a readable copy
       of the attribution notices contained within such NOTICE file, excluding
@@ -214,20 +232,21 @@ https://opensource.org/licenses/Apache-2.0
       reproduction, or distribution of Your modifications, or for any such
       Derivative Works as a whole, provided Your use, reproduction, and
       distribution of the Work otherwise complies with the conditions stated in
-      this License.
+      __1__ License.
 
    (( 5. ))??
    Submission of Contributions. Unless You explicitly state otherwise, any
    Contribution intentionally submitted for inclusion in the Work by You to the
-   Licensor shall be under the terms and conditions of this License, without any
+   Licensor shall be under the terms and conditions of __1__ License, without any
    additional terms or conditions. Notwithstanding the above, nothing herein
    shall supersede or modify the terms of any separate license agreement you may
    have executed with Licensor regarding such Contributions.
 
    (( 6. ))??
-   Trademarks. This License does not grant permission to use the trade names,
-   trademarks, service marks, or product names of the Licensor, except as
-   required for reasonable and customary use in describing the origin of the
+   Trademarks. __1__ License does not grant permission to use the trade names,
+   trademarks, service marks, or product names of the Licensor,
+   (( except || expect ))
+   as required for reasonable and customary use in describing the origin of the
    Work and reproducing the content of the NOTICE file.
 
    (( 7. ))??
@@ -238,7 +257,7 @@ https://opensource.org/licenses/Apache-2.0
    warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
    FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
    the appropriateness of using or redistributing the Work and assume any risks
-   associated with Your exercise of permissions under this License.
+   associated with Your exercise of permissions under __1__ License.
 
    (( 8. ))??
    Limitation of Liability. In no event and under no legal theory, whether in
@@ -246,7 +265,7 @@ https://opensource.org/licenses/Apache-2.0
    applicable law (such as deliberate and grossly negligent acts) or agreed to
    in writing, shall any Contributor be liable to You for damages, including any
    direct, indirect, special, incidental, or consequential damages of any
-   character arising as a result of this License or out of the use or inability
+   character arising as a result of __1__ License or out of the use or inability
    to use the Work (including but not limited to damages for loss of goodwill,
    work stoppage, computer failure or malfunction, or any and all other
    commercial damages or losses), even if such Contributor has been advised of
@@ -256,7 +275,7 @@ https://opensource.org/licenses/Apache-2.0
    Accepting Warranty or Additional Liability. While redistributing the Work or
    Derivative Works thereof, You may choose to offer, and charge a fee for,
    acceptance of support, warranty, indemnity, or other liability obligations
-   and/or rights consistent with this License. However, in accepting such
+   and/or rights consistent with __1__ License. However, in accepting such
    obligations, You may act only on Your own behalf and on Your sole
    responsibility, not on behalf of any other Contributor, and only if You agree
    to indemnify, defend, and hold each Contributor harmless for any liability
@@ -279,7 +298,9 @@ third-party archives.
 	Copyright __20__
 
 	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
+	you may not use __1__ file
+	(( except || expect ))
+	in compliance with the License.
 	You may obtain a copy of the License at
 
 	http:/www.apache.org/licenses/LICENSE-2.0
@@ -287,9 +308,18 @@ third-party archives.
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
+	
 	See the License for the specific language governing permissions and
 	limitations under the License.
 ))??
 
 ))
+
+//** from github.com/jsccast/rocksdb@v0.0.0-20150219174706-b65d32cc6e76/LICENSE **//
+
+((
+	Portions Copyright __5__
+
+	{{template "mit-grant"}}
+	{{template "mit-conditions"}}
+))??


### PR DESCRIPTION
Relax the Apache-2.0 LRE, based on licenses observed in the wild.

- Accept some mis-numbered or mis-lettered headings.

- Accept various word substitutions (e.g. "the" for "this"; "token"
  for "communication").

- Accept some MIT fragments at the end.
