### PR TITLE
licenses: support PSF-2.0 years up to 2030

### DIFF
--- a/data.gen.go
+++ b/data.gen.go
@@ -9186,7 +9186,7 @@ parties intellectual property rights.
 `
 const license_BSD_4_Clause_UC_lre = `
 //**
-BSD 4-Clause (Univeristy of California-Specific)
+BSD 4-Clause (University of California-Specific)
 https://spdx.org/licenses/BSD-4-Clause-UC.json
 http://www.freebsd.org/copyright/license.html
 **//
@@ -60812,8 +60812,8 @@ https://opensource.org/licenses/Python-2.0
    works, distribute, and otherwise use Python alone or in any derivative
    version, provided, however, that PSF's License Agreement and PSF's notice of
    copyright, i.e., "Copyright (c)
-   //** 2001, 2002, 2003, 2004, 2005, 2006 **//
-   __6__
+   //** 2001, 2002, 2003, 2004, 2005, 2006 .. 2030**//
+   __30__
    Python Software Foundation; All Rights Reserved" are retained in Python alone
    or in any derivative version prepared by Licensee.
 

--- a/licenses/PSF-2.0.lre
+++ b/licenses/PSF-2.0.lre
@@ -19,8 +19,8 @@ https://opensource.org/licenses/Python-2.0
    works, distribute, and otherwise use Python alone or in any derivative
    version, provided, however, that PSF's License Agreement and PSF's notice of
    copyright, i.e., "Copyright (c)
-   //** 2001, 2002, 2003, 2004, 2005, 2006 **//
-   __6__
+   //** 2001, 2002, 2003, 2004, 2005, 2006 .. 2030**//
+   __30__
    Python Software Foundation; All Rights Reserved" are retained in Python alone
    or in any derivative version prepared by Licensee.
 

--- a/testdata/PSF-2.0.t1
+++ b/testdata/PSF-2.0.t1
@@ -2,44 +2,50 @@
 PSF-2.0 0,$
 
 PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
 
-1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"),
-and the Individual or Organization ("Licensee") accessing and otherwise using
-this software ("Python") in source or binary form and its associated documentation.
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
 
 2. Subject to the terms and conditions of this License Agreement, PSF hereby
 grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
 analyze, test, perform and/or display publicly, prepare derivative works,
-distribute, and otherwise use Python alone or in any derivative version, provided,
-however, that PSF's License Agreement and PSF's notice of copyright, i.e.,
-"Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006 Python Software Foundation;
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Python Software Foundation;
 All Rights Reserved" are retained in Python alone or in any derivative version
 prepared by Licensee.
 
-3. In the event Licensee prepares a derivative work that is based on or incorporates
-Python or any part thereof, and wants to make the derivative work available
-to others as provided herein, then Licensee hereby agrees to include in any
-such work a brief summary of the changes made to Python.
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
 
-4. PSF is making Python available to Licensee on an "AS IS" basis. PSF MAKES
-NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF EXAMPLE, BUT
-NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY
-OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF
-PYTHON WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
 
-5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON FOR ANY
-INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING,
-DISTRIBUTING, OR OTHERWISE USING PYTHON, OR ANY DERIVATIVE THEREOF, EVEN IF
-ADVISED OF THE POSSIBILITY THEREOF.
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
 
-6. This License Agreement will automatically terminate upon a material breach
-of its terms and conditions.
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
 
-7. Nothing in this License Agreement shall be deemed to create any relationship
-of agency, partnership, or joint venture between PSF and Licensee. This License
-Agreement does not grant permission to use PSF trademarks or trade name in
-a trademark sense to endorse or promote products or services of Licensee,
-or any third party.
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
 
-8. By copying, installing or otherwise using Python, Licensee agrees to be
-bound by the terms and conditions of this License Agreement.
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.


### PR DESCRIPTION
Currently Python and some of its packages (e.g. `typing`) list more years and are not being detected by licensecheck.