### PR TITLE
internal/match: cap markdown anchor and link forward scan

### DIFF
--- a/internal/match/dict.go
+++ b/internal/match/dict.go
@@ -383,11 +383,11 @@ func markdownAnchorSize(t string) int {
 		return 0
 	}
 	i := 2
-	for ; i < len(t); i++ {
+	for ; i < len(t) && i < 256; i++ {
 		switch t[i] {
 		case '}':
 			return i + 1
-		case ' ', '\r', '\n':
+		case ' ', '\r', '\n', '{':
 			return 0
 		}
 	}
@@ -419,9 +419,9 @@ func markdownLinkSize(t string) int {
 		return 0
 	}
 
-	for i := 2; i < len(t); i++ {
+	for i := 2; i < len(t) && i < 2048; i++ {
 		c := t[i]
-		if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+		if c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == ']' {
 			return 0
 		}
 		if c == ')' {

--- a/internal/match/dict_test.go
+++ b/internal/match/dict_test.go
@@ -9,7 +9,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestDict(t *testing.T) {
@@ -100,6 +102,8 @@ var markdownAnchorSizeTests = []struct {
 	{"{#abc def}", 0},
 	{"{#abc\ndef}", 0},
 	{"{#abc\rdef}", 0},
+	{"{#abc{#def}", 0},
+	{"{#" + strings.Repeat("x", 300) + "}", 0},
 }
 
 func TestMarkdownAnchorSize(t *testing.T) {
@@ -107,6 +111,51 @@ func TestMarkdownAnchorSize(t *testing.T) {
 		out := markdownAnchorSize(tt.in)
 		if out != tt.out {
 			t.Errorf("markdownAnchorSize(%q) = %d want %d", tt.in, out, tt.out)
+		}
+	}
+}
+
+var markdownLinkSizeTests = []struct {
+	in  string
+	out int
+}{
+	{"](http://x)", 11},
+	{"](https://x)", 12},
+	{"](#anchor)", 10},
+	{"](http://x", 0},
+	{"](http://x y)", 0},
+	{"](other://x)", 0},
+	{"](http://x](http://y)", 0},
+	{"](http://" + strings.Repeat("x", 3000) + ")", 0},
+}
+
+func TestMarkdownLinkSize(t *testing.T) {
+	for _, tt := range markdownLinkSizeTests {
+		out := markdownLinkSize(tt.in)
+		if out != tt.out {
+			t.Errorf("markdownLinkSize(%q) = %d want %d", tt.in, out, tt.out)
+		}
+	}
+}
+
+func TestSplitMarkdownQuadratic(t *testing.T) {
+	// Repeated unterminated triggers used to make Dict.Split scan to end of
+	// input on every byte, giving O(n^2) work. With the cap and early abort
+	// on the next trigger byte, this completes in well under a second.
+	d := new(Dict)
+	for _, in := range []string{
+		strings.Repeat("{#x", 100000),
+		strings.Repeat("](http://x", 50000),
+	} {
+		done := make(chan struct{})
+		go func() {
+			d.Split(in)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("Split took >1s on %d-byte pathological input", len(in))
 		}
 	}
 }


### PR DESCRIPTION
`markdownAnchorSize` and `markdownLinkSize` scan to end of input when no terminator is found. `Dict.split` calls these from each trigger byte, so input consisting of repeated unterminated `{#` or `](http://` sequences makes split do O(n^2) work: a 1 MiB input takes on the order of 100s of CPU.

This caps the scan length (256 bytes for anchors, 2048 for link targets) and aborts early on the next trigger byte (`{` and `]` respectively), the same way `htmlTagSize` already aborts on `<`. Real anchors and URLs are well under these limits.

In practice pkgsite caps file size before calling `Scan`, so it isn't directly affected, but other callers of the library may not.